### PR TITLE
Made python path for libepoxy and gtk3 configurable

### DIFF
--- a/build.py
+++ b/build.py
@@ -589,7 +589,7 @@ class Project_gtk3(Project_gtk_base):
             )
 
     def build(self):
-        self.exec_msbuild(r'build\win32\vs%(vs_ver)s\gtk+.sln /p:GtkPostInstall=rem')
+        self.exec_msbuild(r'build\win32\vs%(vs_ver)s\gtk+.sln /p:GtkPostInstall=rem /p:PythonPath=%(python_dir)s')
 
         super(Project_gtk3, self).build()
 
@@ -685,7 +685,7 @@ class Project_libepoxy(Tarball, Project):
             )
 
     def build(self):
-        self.exec_msbuild(r'build\win32\vs%(vs_ver)s\epoxy.sln')
+        self.exec_msbuild(r'build\win32\vs%(vs_ver)s\epoxy.sln /p:PythonPath=%(python_dir)s')
 
 Project.add(Project_libepoxy())
 


### PR DESCRIPTION
Building of libepoxy and gtk3 will fail if python is not installed in c:\python27 because the path is hardcoded. I created a little patch which makes these two packages take the "--python-dir" command line switch into account.