### PR TITLE
Fixed error build the 'gettext' project for the vs14 support

### DIFF
--- a/gettext/build/win32/vs14/gettext-version-paths.props
+++ b/gettext/build/win32/vs14/gettext-version-paths.props
@@ -4,13 +4,13 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros">
     <VSVer>14</VSVer>
-    <GlibEtcInstallRoot>$(SolutionDir)\..\..\vs$(VSVer)\$(Configuration)\$(Platform)</GlibEtcInstallRoot>
-    <CopyDir>$(GlibEtcInstallRoot)</CopyDir>
+    <GlibEtcInstallRoot>$(SolutionDir)\..\..\..\..\..\..\..\gtk\$(Platform)\$(Configuration)</GlibEtcInstallRoot>
+    <CopyDir>..\..\..\..\gettext-rel</CopyDir>
     <PackageVersionMajor>0</PackageVersionMajor>
     <PackageVersionMinor>19</PackageVersionMinor>
     <PackageVersionMicro>7</PackageVersionMicro>
     <PackageVersionString>$(PackageVersionMajor).$(PackageVersionMinor).$(PackageVersionMicro)</PackageVersionString>
-    <InstallRoot>c:/win32_bin_vc$(VSVer).0</InstallRoot>
+    <InstallRoot>$(SolutionDir)\..\..\..\..\..\..\..\gtk\$(Platform)\$(Configuration)</InstallRoot>
     <DataDir>$(InstallRoot)/share</DataDir>
     <LibDir>$(InstallRoot)/share</LibDir>
   </PropertyGroup>
@@ -40,6 +40,9 @@
     <BuildMacro Include="CopyDir">
       <Value>$(CopyDir)</Value>
     </BuildMacro>
+    <BuildMacro Include="PackageVersionMajor">
+      <Value>$(PackageVersionMajor)</Value>
+    </BuildMacro>
     <BuildMacro Include="PackageVersionMinor">
       <Value>$(PackageVersionMinor)</Value>
     </BuildMacro>
@@ -48,9 +51,6 @@
     </BuildMacro>
     <BuildMacro Include="PackageVersionString">
       <Value>$(PackageVersionString)</Value>
-    </BuildMacro>
-    <BuildMacro Include="PackageVersionMajor">
-      <Value>$(PackageVersionMajor)</Value>
     </BuildMacro>
     <BuildMacro Include="InstallRoot">
       <Value>$(InstallRoot)</Value>


### PR DESCRIPTION
Error build the 'gettext' project for the Visual Studio 2015 support:

`
C:\gtk-build\build\x64\release\gettext\gettext-tools\gnulib-lib\msvc\iconv.h(27): fatal error C1083: Cannot open include file: '../include/iconv.h': No such file or directory (compiling source file ..\..\..\gettext-tools\gnulib-lib\libxml\xmlIO.c) [C:\gtk-build\build\x64\release\gettext\build\win32\vs14\libxml_rpl.vcxproj]
`