### PR TITLE
Avoid an exception if no subparser (build, list) set and print the co…

### DIFF
--- a/build.py
+++ b/build.py
@@ -1890,4 +1890,8 @@ if __name__ == '__main__':
     parser = create_parser()
     args = parser.parse_args()
     handle_global_options(args)
-    args.func(args)
+    if hasattr(args, 'func'):
+        args.func(args)
+    else:
+        parser.print_help()
+        


### PR DESCRIPTION
…mplete usage

With python 3.4 if no subparser option is put there is an exception instead of the printing of the simple usage. 
With this changed in case the fulll help is printed 
 