### PR TITLE
Build pkg-config (0.29.1) and install in the Gtk stack

### DIFF
--- a/build.py
+++ b/build.py
@@ -1492,6 +1492,31 @@ Project.add(MercurialCmakeProject('pygobject', repo_url='git+ssh://git@github.co
 Project.add(MercurialCmakeProject('pygtk', repo_url='git+ssh://git@github.com:muntyan/pygtk-gtk-win32.git', dependencies = ['gtk', 'pycairo', 'pygobject']))
 
 
+class Project_pkg_config(Tarball, Project):
+    def __init__(self):
+        Project.__init__(self,
+            'pkg-config',
+            archive_url = 'https://pkg-config.freedesktop.org/releases/pkg-config-0.29.1.tar.gz',
+            hash = 'beb43c9e064555469bd4390dcfd8030b1536e0aa103f08d7abf7ae8cac0cb001',
+            dependencies = ['glib', ],
+            patches = ['001-pkg-config-set-glib-prefix.patch',
+                      ],
+            )
+
+    def build(self):
+        ## self.push_location(r'.')
+        self.exec_vs(r'nmake /nologo /f Makefile.vc CFG=%(configuration)s GLIB_PREFIX="%(gtk_dir)s"')
+        ## self.pop_location()
+
+        bin_dir = r'.\%s\%s' % (self.builder.opts.configuration, self.builder.opts.platform, )
+        self.install(bin_dir + r'\pkg-config.exe bin')
+        self.install(bin_dir + r'\pkg-config.pdb bin')
+
+        self.install(r'.\COPYING share\doc\pkg-config')
+
+Project.add(Project_pkg_config())
+
+
 #========================================================================================================================================================
 
 global_verbose = False

--- a/build.py
+++ b/build.py
@@ -1324,6 +1324,27 @@ class Project_pixman(Tarball, Project):
 
 Project.add(Project_pixman())
 
+class Project_pkg_config(Tarball, Project):
+    def __init__(self):
+        Project.__init__(self,
+            'pkg-config',
+            archive_url = 'https://pkg-config.freedesktop.org/releases/pkg-config-0.29.1.tar.gz',
+            hash = 'beb43c9e064555469bd4390dcfd8030b1536e0aa103f08d7abf7ae8cac0cb001',
+            dependencies = ['glib', ],
+            patches = ['001-pkg-config-set-glib-prefix.patch' ],
+            )
+
+    def build(self):
+        self.exec_vs(r'nmake /nologo /f Makefile.vc CFG=%(configuration)s GLIB_PREFIX="%(gtk_dir)s"')
+
+        bin_dir = r'.\%s\%s' % (self.builder.opts.configuration, self.builder.opts.platform, )
+        self.install(bin_dir + r'\pkg-config.exe bin')
+        self.install(bin_dir + r'\pkg-config.pdb bin')
+
+        self.install(r'.\COPYING share\doc\pkg-config')
+
+Project.add(Project_pkg_config())
+
 class Project_portaudio(Tarball, Project):
     def __init__(self):
         Project.__init__(self,
@@ -1490,31 +1511,6 @@ class MercurialCmakeProject(MercurialRepo, CmakeProject):
 Project.add(MercurialCmakeProject('pycairo', repo_url='git+ssh://git@github.com:muntyan/pycairo-gtk-win32.git', dependencies = ['cairo']))
 Project.add(MercurialCmakeProject('pygobject', repo_url='git+ssh://git@github.com:muntyan/pygobject-gtk-win32.git', dependencies = ['glib']))
 Project.add(MercurialCmakeProject('pygtk', repo_url='git+ssh://git@github.com:muntyan/pygtk-gtk-win32.git', dependencies = ['gtk', 'pycairo', 'pygobject']))
-
-
-class Project_pkg_config(Tarball, Project):
-    def __init__(self):
-        Project.__init__(self,
-            'pkg-config',
-            archive_url = 'https://pkg-config.freedesktop.org/releases/pkg-config-0.29.1.tar.gz',
-            hash = 'beb43c9e064555469bd4390dcfd8030b1536e0aa103f08d7abf7ae8cac0cb001',
-            dependencies = ['glib', ],
-            patches = ['001-pkg-config-set-glib-prefix.patch',
-                      ],
-            )
-
-    def build(self):
-        ## self.push_location(r'.')
-        self.exec_vs(r'nmake /nologo /f Makefile.vc CFG=%(configuration)s GLIB_PREFIX="%(gtk_dir)s"')
-        ## self.pop_location()
-
-        bin_dir = r'.\%s\%s' % (self.builder.opts.configuration, self.builder.opts.platform, )
-        self.install(bin_dir + r'\pkg-config.exe bin')
-        self.install(bin_dir + r'\pkg-config.pdb bin')
-
-        self.install(r'.\COPYING share\doc\pkg-config')
-
-Project.add(Project_pkg_config())
 
 
 #========================================================================================================================================================

--- a/build.py
+++ b/build.py
@@ -1330,8 +1330,8 @@ class Project_pkg_config(Tarball, Project):
             'pkg-config',
             archive_url = 'https://pkg-config.freedesktop.org/releases/pkg-config-0.29.1.tar.gz',
             hash = 'beb43c9e064555469bd4390dcfd8030b1536e0aa103f08d7abf7ae8cac0cb001',
-            dependencies = ['glib', ],
-            patches = ['001-pkg-config-set-glib-prefix.patch' ],
+            dependencies = [ 'glib', ],
+            patches = [ '001-pkg-config-set-glib-prefix.patch' ],
             )
 
     def build(self):

--- a/pkg-config/001-pkg-config-set-glib-prefix.patch
+++ b/pkg-config/001-pkg-config-set-glib-prefix.patch
@@ -1,0 +1,12 @@
+--- org/Makefile.vc        2017-01-23 19:27:19.473928700 +0100
++++ Makefile.vc      2017-01-23 19:25:57.354615200 +0100
+@@ -8,7 +8,9 @@
+ # in $(GLIB_PREFIX)\include\glib-2.0 and $(GLIB_PREFIX)\lib\glib-2.0\include
+ # and its import library will be found in $(GLIB_PREFIX)\lib.
+
++!if "$(GLIB_PREFIX)" == ""
+ GLIB_PREFIX = ..\vs$(VSVER)\$(PLAT)
++!endif
+
+ # The items below this line should not be changed, unless one is maintaining
+ # the NMake Makefiles.


### PR DESCRIPTION
This build pkg-config and install it in the gtk bin dir. 

It's different from the one you can get and use from msys2 because the --msvc-syntax option is present to output the libs & cflags data in Visual Studio format.

It's also needed to build the gobject introspection gir/typelibs files.