### PR TITLE
#107: Download nuget.exe automatically & only if needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ HexChat developers decided that their script should focus on their specific need
     * [msys2](https://msys2.github.io/)
     * Perl 5.20 [x86](https://dl.hexchat.net/misc/perl/perl-5.20.0-x86.7z) or [x64](https://dl.hexchat.net/misc/perl/perl-5.20.0-x64.7z) (extract to _C:\perl_)
     * [Python 3.4](https://www.python.org/ftp/python/2.7.9/python-2.7.9.amd64.msi) (install in C:\Python34), or other package like [Miniconda 3.4](https://repo.continuum.io/miniconda/Miniconda3-latest-Windows-x86_64.exe)
-    * [nuget](https://dist.nuget.org/win-x86-commandline/latest/nuget.exe) (install in C:\gtk-build\nuget)
 
 1. Follow the instructions on the msys2 page to update the core packages.
 

--- a/build.py
+++ b/build.py
@@ -109,6 +109,9 @@ class Project(object):
     def __repr__(self):
         return repr(self.name)
 
+    def preprocess(self, builder):
+        pass 
+
     def build(self):
         raise NotImplementedError()
 
@@ -198,6 +201,44 @@ class Project(object):
     @staticmethod
     def get_dict():
         return dict(Project._dict)
+
+#==============================================================================
+# Tools used to build the various projects
+#==============================================================================
+
+class Project_nuget(Project):
+    def __init__(self):
+        Project.__init__(self,
+            'nuget',
+            archive_url = 'https://dist.nuget.org/win-x86-commandline/latest/nuget.exe',
+            hash = '399ec24c26ed54d6887cde61994bb3d1cada7956c1b19ff880f06f060c039918')
+
+    def preprocess(self, builder):
+        if builder.nuget:
+            # nuget path passed on the command line, we don't download anything
+            self.archive_file = None 
+    
+    def unpack(self):
+        # Nothing to do :)
+        pass
+
+    def build(self):
+        if not self.builder.nuget:
+            # We download directly the exe file so we copy it on the tool directory ...
+            destdir = os.path.join(self.builder.opts.tools_root_dir, 'nuget')
+            destfile = os.path.join(destdir, 'nuget.exe')
+            if not os.path.isfile(destfile):
+                print_log("Copying file to tools directory (%s)" % (destfile, ))
+                self.builder.make_dir(destdir)
+                shutil.copy2(self.archive_file, destfile)
+            # .. and set the builder object to point to the file
+            self.builder.nuget = destfile
+
+Project.add(Project_nuget())
+
+#==============================================================================
+# Projects
+#==============================================================================
 
 class Project_adwaita_icon_theme(Tarball, Project):
     def __init__(self):
@@ -564,7 +605,7 @@ class Project_grpc(GitRepo, Project):
             repo_url = 'https://github.com/grpc/grpc.git',
             fetch_submodules = True,
             tag = 'v1.0.0',
-            dependencies = ['protobuf'],
+            dependencies = ['nuget', 'protobuf'],
             patches = ['0001-Remove-RuntimeLibrary-setting-from-the-projects.patch'],
             )
 
@@ -1588,8 +1629,10 @@ class Builder(object):
         print_debug("wget: %s" % (self.wget,))
 
         self.nuget = opts.nuget_path
-        if not os.path.exists(self.nuget):
-            print_log("Could not find nuget: %s" % (self.nuget,))
+        if opts.nuget_path:
+            # if we setup the path we check it, otherwise we download & install in a default location
+            if not os.path.exists(self.nuget):
+                print_log("Could not find nuget: %s" % (self.nuget,))
 
     def __check_vs(self, opts):
         # Verify VS exists at the indicated location, and that it supports the required target
@@ -1628,6 +1671,7 @@ class Builder(object):
             proj.build_dir = os.path.join(self.working_dir, proj.name)
             proj.dependencies = [Project.get_project(dep) for dep in proj.dependencies]
             proj.dependents = []
+            proj.preprocess(self)
 
         for proj in Project.list_projects():
             self.__compute_deps(proj)
@@ -1843,6 +1887,7 @@ def get_options(args):
     opts.build_dir = args.build_dir
     opts.archives_download_dir = args.archives_download_dir
     opts.patches_root_dir = args.patches_root_dir
+    opts.tools_root_dir = args.tools_root_dir
     opts.vs_ver = args.vs_ver
     opts.vs_install_path = args.vs_install_path
     opts.cmake_path = args.cmake_path
@@ -1857,10 +1902,10 @@ def get_options(args):
 
     if not opts.archives_download_dir:
         opts.archives_download_dir = os.path.join(args.build_dir, 'src')
-    if not opts.nuget_path:
-        opts.nuget_path = os.path.join(args.build_dir, 'nuget', 'nuget.exe')
     if not opts.patches_root_dir:
         opts.patches_root_dir = sys.path[0]
+    if not opts.tools_root_dir:
+        opts.tools_root_dir = os.path.join(args.build_dir, 'tools')
     if not opts.vs_install_path:
         opts.vs_install_path = r'C:\Program Files (x86)\Microsoft Visual Studio %s.0' % (opts.vs_ver,)
 
@@ -1959,6 +2004,8 @@ Examples:
                               "Default is $(build-dir)\\src.")
     p_build.add_argument('--patches-root-dir',
                          help="The directory where you checked out https://github.com/wingtk/gtk-win32.git. Default is $(build-dir)\\github\\gtk-win32.")
+    p_build.add_argument('--tools-root-dir',
+                         help="The directory where to install the downloaded tools. Default is $(build-dir)\\tools.")
     p_build.add_argument('--vs-ver', default='12',
                          help="Visual Studio version 10,12,14, etc. Default is 12.")
     p_build.add_argument('--vs-install-path',
@@ -2003,4 +2050,4 @@ if __name__ == '__main__':
         args.func(args)
     else:
         parser.print_help()
-        
+


### PR DESCRIPTION
This patch allow the automatic download & installation of nuget, only if needed (actually by grpc) or if asked on the command line.

I put the nuget project at the beginning and not in alphabetic order to separate the things we build from the one needed for the build (in preparation for #108).

I also put a global configuration for the directory to put the tools in so we have c:\gtk-build\tools\nuget, c:\gtk-build\tools\ninja, ....

The file is dowloaded in the same directory of the source tarballs

If you pass the nuget path to the script (because you already have it or you want to use a particular version) nothing is downloaded and the one passed is used.

Actually the opts and the checks of this options are handled on the global build parser (and with only one project is ok) but if we need to add ninja, meson and other (maybe perl) probably is better to add a method on the class to add the option so we can also configure the singles projects, for example to build Gdk with the broadway backend :)

Thanks in advance