### PR TITLE
Download and install (locally) ninja.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ HexChat developers decided that their script should focus on their specific need
 1. Install needed packages in the msys2 shell
 
     ```bash
-    pacman -S gzip nasm patch tar xz gettext make coreutils diffutils wget yasm pkg-config
+    pacman -S gzip nasm patch tar xz gettext make coreutils diffutils wget yasm pkg-config unzip
     ```
 
 1. Clone [this repository](https://github.com/wingtk/gtk-win32) to _C:\gtk-build\github\gtk-win32_ It contains the build script, project files and patches.

--- a/build.py
+++ b/build.py
@@ -220,7 +220,6 @@ class Project_ninja(Project):
             self.builder.exec_msys('%s -o %s -d %s' % (self.builder.unzip, self.archive_file, destdir, ))
         # .. and set the builder object to point to the file
         self.builder.ninja = destfile
-        pass
 
     def build(self):
         # Nothing to do :)

--- a/build.py
+++ b/build.py
@@ -203,6 +203,31 @@ class Project(object):
 # Tools used to build the various projects
 #==============================================================================
 
+class Project_ninja(Project):
+    def __init__(self):
+        Project.__init__(self,
+            'ninja',
+            archive_url = 'https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-win.zip',
+            hash = '95b36a597d33c1fe672829cfe47b5ab34b3a1a4c6bf628e5d150b6075df4ef50')
+
+    def unpack(self):
+        # We download a .zip file so we estract it in the tool directory ...
+        destdir = os.path.join(self.builder.opts.tools_root_dir, 'ninja')
+        destfile = os.path.join(destdir, 'ninja.exe')
+        if not os.path.isfile(destfile):
+            print_log("Unpacking ninja le to tools directory (%s)" % (destfile, ))
+            self.builder.make_dir(destdir)
+            self.builder.exec_msys('%s -o %s -d %s' % (self.builder.unzip, self.archive_file, destdir, ))
+        # .. and set the builder object to point to the file
+        self.builder.ninja = destfile
+        pass
+
+    def build(self):
+        # Nothing to do :)
+        pass
+
+Project.add(Project_ninja())
+
 class Project_nuget(Project):
     def __init__(self):
         Project.__init__(self,
@@ -1616,6 +1641,11 @@ class Builder(object):
         if not os.path.exists(self.wget):
             error_exit("%s not found. Please check that you installed wget in msys2 using ``pacman -S wget``" % (self.wget,))
         print_debug("wget: %s" % (self.wget,))
+
+        self.unzip = os.path.join(opts.msys_dir, 'usr', 'bin', 'unzip.exe')
+        if not os.path.exists(self.unzip):
+            error_exit("%s not found. Please check that you installed unzip in msys2 using ``pacman -S unzip``" % (self.unzip,))
+        print_debug("unzip: %s" % (self.unzip,))
 
     def __check_vs(self, opts):
         # Verify VS exists at the indicated location, and that it supports the required target


### PR DESCRIPTION
This seems easy ...

The unzip program is been added to the msys2 requirement.

I call exec_msys(...) while maybe it's been better to call directly __execute(...) but it's local to the builder class. 

We can avoid the check of the presence of the unzip.exe and call exec_msys('unzip -o ...' ) but I think in this way is clearer what happens and maybe the unzip is needed in teh future.
