### PR TITLE
Add the builded gtk paths (INCLUDE, LIB, LIBPATH, PATH) to the vs env…

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ HexChat developers decided that their script should focus on their specific need
 1. Install needed packages in the msys2 shell
 
     ```bash
-    pacman -S gzip nasm patch tar xz gettext make coreutils diffutils wget yasm pkg-config
+    pacman -S gzip nasm patch tar xz gettext make coreutils diffutils wget yasm pkg-config unzip
     ```
 
 1. Clone [this repository](https://github.com/wingtk/gtk-win32) to _C:\gtk-build\github\gtk-win32_ It contains the build script, project files and patches.

--- a/build.py
+++ b/build.py
@@ -203,6 +203,30 @@ class Project(object):
 # Tools used to build the various projects
 #==============================================================================
 
+class Project_ninja(Project):
+    def __init__(self):
+        Project.__init__(self,
+            'ninja',
+            archive_url = 'https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-win.zip',
+            hash = '95b36a597d33c1fe672829cfe47b5ab34b3a1a4c6bf628e5d150b6075df4ef50')
+
+    def unpack(self):
+        # We download a .zip file so we estract it in the tool directory ...
+        destdir = os.path.join(self.builder.opts.tools_root_dir, 'ninja')
+        destfile = os.path.join(destdir, 'ninja.exe')
+        if not os.path.isfile(destfile):
+            print_log("Unpacking ninja le to tools directory (%s)" % (destfile, ))
+            self.builder.make_dir(destdir)
+            self.builder.exec_msys('%s -o %s -d %s' % (self.builder.unzip, self.archive_file, destdir, ))
+        # .. and set the builder object to point to the file
+        self.builder.ninja = destfile
+
+    def build(self):
+        # Nothing to do :)
+        pass
+
+Project.add(Project_ninja())
+
 class Project_nuget(Project):
     def __init__(self):
         Project.__init__(self,
@@ -734,8 +758,8 @@ class Project_harfbuzz(Tarball, Project):
     def __init__(self):
         Project.__init__(self,
             'harfbuzz',
-            archive_url = 'https://www.freedesktop.org/software/harfbuzz/release/harfbuzz-1.4.0.tar.bz2',
-            hash = '8497eca976f3c4cdee7f46ffc228d755d2f0651da7c253fa6ae99d5a61ddd1b5',
+            archive_url = 'https://www.freedesktop.org/software/harfbuzz/release/harfbuzz-1.4.2.tar.bz2',
+            hash = '8f234dcfab000fdec24d43674fffa2fdbdbd654eb176afbde30e8826339cb7b3',
             dependencies = ['freetype', 'glib'],
             )
 
@@ -1616,6 +1640,11 @@ class Builder(object):
         if not os.path.exists(self.wget):
             error_exit("%s not found. Please check that you installed wget in msys2 using ``pacman -S wget``" % (self.wget,))
         print_debug("wget: %s" % (self.wget,))
+
+        self.unzip = os.path.join(opts.msys_dir, 'usr', 'bin', 'unzip.exe')
+        if not os.path.exists(self.unzip):
+            error_exit("%s not found. Please check that you installed unzip in msys2 using ``pacman -S unzip``" % (self.unzip,))
+        print_debug("unzip: %s" % (self.unzip,))
 
     def __check_vs(self, opts):
         # Verify VS exists at the indicated location, and that it supports the required target

--- a/build.py
+++ b/build.py
@@ -219,9 +219,8 @@ class Meson(Project):
             add_opts = '--buildtype ' + self.builder.opts.configuration
             # pyhon meson.py ninja_build_dir --prefix gtk_bin options
             cmd = '%s\\python.exe %s %s --prefix %s %s' % (self.builder.opts.python_dir, self.builder.meson, ninja_build, self.builder.gtk_dir, add_opts, )
-            # ninja in front, then the gtk bin for pkg-config
-            add_path = ';'.join([self.builder.ninja_path,
-                                 os.path.join(self.builder.gtk_dir, 'bin')])
+            # add ninja path, the gtk ones are in the vs environment
+            add_path = self.builder.ninja_path
             # build the ninja file to do everything (build the library, create the .pc file, install it, ...)
             self.exec_vs(cmd, add_path=add_path)
         # we simply run 'ninja install' that takes care of everything, running explicity from the build dir
@@ -1721,6 +1720,18 @@ class Builder(object):
             error_exit("%s not found. Please check that you installed unzip in msys2 using ``pacman -S unzip``" % (self.unzip,))
         print_debug("unzip: %s" % (self.unzip,))
 
+    def add_env(self, key, value, prepend=True):
+        env = os.environ
+        te = env.get(key, None)
+        if te:
+            if prepend:
+                env[key] = value + ';' + te
+            else:
+                env[key] = te + ';' + value
+        else:
+            # not set
+            env[key] = value
+
     def __check_vs(self, opts):
         # Verify VS exists at the indicated location, and that it supports the required target
         if opts.platform in ('Win32', 'win32', 'x86'):
@@ -1740,11 +1751,18 @@ class Builder(object):
         if not os.path.exists(vcvars_bat):
             raise Exception("'%s' could not be found. Please check you have Visual Studio installed at '%s' and that it supports the target platform '%s'." % (vcvars_bat, opts.vs_install_path, opts.platform))
 
+        # Add to the environment the gtk paths so meson can find everything
+        self.add_env('INCLUDE', os.path.join(self.gtk_dir, 'include'))
+        self.add_env('LIB', os.path.join(self.gtk_dir, 'lib'))
+        self.add_env('LIBPATH', os.path.join(self.gtk_dir, 'lib'))
+        self.add_env('PATH', os.path.join(self.gtk_dir, 'bin'))
+
         output = subprocess.check_output('cmd.exe /c ""%s" && set"' % (vcvars_bat,), shell=True)
         self.vs_env = {}
         for l in output.splitlines():
             k, v = l.decode('utf-8').split("=", 1)
             self.vs_env[k] = v
+            print_debug('vs env:%s -> [%s]' % (k, v, ))
 
     def preprocess(self):
         for proj in Project.list_projects():

--- a/build.py
+++ b/build.py
@@ -110,6 +110,10 @@ class Project(object):
     def __repr__(self):
         return repr(self.name)
 
+    def load_defaults(self, builder):
+        # Used by the tools to load default paths/filenames 
+        pass
+    
     def build(self):
         raise NotImplementedError()
 
@@ -235,18 +239,19 @@ class Project_meson(Project):
             hash = '66d90df0ae665b1cdf036dbd9531fd77e62e3ccaae76c10b0652646d4009e384',
             dir_part = 'meson-0.38.1')
 
+    def load_defaults(self, builder):
+        # Set the builder object to point to the file to use
+        builder.meson = os.path.join(builder.opts.tools_root_dir, self.dir_part, 'meson.py')
+        
     def unpack(self):
         # We download a .zip file so we estract it in the tool directory, with the version ...
-        destdir = os.path.join(self.builder.opts.tools_root_dir, self.dir_part)
-        destfile = os.path.join(destdir, 'meson.py')
-        if not os.path.isfile(destfile):
-            print_log("Unpacking meson to tools directory (%s)" % (destfile, ))
+        if not os.path.isfile(self.builder.meson):
+            destdir = os.path.join(self.builder.opts.tools_root_dir, self.dir_part)
+            print_log("Unpacking meson to tools directory (%s)" % (self.builder.meson, ))
             self.builder.make_dir(destdir)
             with zipfile.ZipFile(self.archive_file) as zf:
                 # In the zip file the dir part (meson-0.xx...) is already present
                 zf.extractall(path=self.builder.opts.tools_root_dir)
-        # .. and set the builder object to point to the file
-        self.builder.meson = destfile
 
     def build(self):
         # Nothing to do :)
@@ -261,17 +266,18 @@ class Project_ninja(Project):
             archive_url = 'https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-win.zip',
             hash = '95b36a597d33c1fe672829cfe47b5ab34b3a1a4c6bf628e5d150b6075df4ef50')
 
+    def load_defaults(self, builder):
+        # Set the builder object to point to the path to use
+        builder.ninja_path = os.path.join(builder.opts.tools_root_dir, 'ninja')
+
     def unpack(self):
         # We download a .zip file so we estract it in the tool directory ...
-        destdir = os.path.join(self.builder.opts.tools_root_dir, 'ninja')
-        destfile = os.path.join(destdir, 'ninja.exe')
+        destfile = os.path.join(self.builder.ninja_path, 'ninja.exe')
         if not os.path.isfile(destfile):
-            print_log("Unpacking ninja le to tools directory (%s)" % (destfile, ))
-            self.builder.make_dir(destdir)
+            print_log("Unpacking ninja to tools directory (%s)" % (destfile, ))
+            self.builder.make_dir(self.builder.ninja_path)?s
             with zipfile.ZipFile(self.archive_file) as zf:
-                zf.extractall(path=destdir)
-        # .. and set the builder object to point to the ninja dir
-        self.builder.ninja_path = destdir
+                zf.extractall(path=self.builder.ninja_path)
 
     def build(self):
         # Nothing to do :)
@@ -286,20 +292,21 @@ class Project_nuget(Project):
             archive_url = 'https://dist.nuget.org/win-x86-commandline/latest/nuget.exe',
             hash = '399ec24c26ed54d6887cde61994bb3d1cada7956c1b19ff880f06f060c039918')
 
+    def load_defaults(self, builder):
+        # Set the builder object to point to the .exe file to use
+        builder.nuget = os.path.join(builder.opts.tools_root_dir, 'nuget', 'nuget.exe') 
+
     def unpack(self):
         # Nothing to do :)
         pass
 
     def build(self):
         # We download directly the exe file so we copy it on the tool directory ...
-        destdir = os.path.join(self.builder.opts.tools_root_dir, 'nuget')
-        destfile = os.path.join(destdir, 'nuget.exe')
-        if not os.path.isfile(destfile):
-            print_log("Copying file to tools directory (%s)" % (destfile, ))
+        if not os.path.isfile(self.builder.nuget):
+            destdir = os.path.join(self.builder.opts.tools_root_dir, 'nuget')
+            print_log("Copying file to tools directory (%s)" % (self.builder.nuget, ))
             self.builder.make_dir(destdir)
-            shutil.copy2(self.archive_file, destfile)
-        # .. and set the builder object to point to the file
-        self.builder.nuget = destfile
+            shutil.copy2(self.archive_file, self.builder.nuget)
 
 Project.add(Project_nuget())
 
@@ -1751,6 +1758,7 @@ class Builder(object):
             proj.build_dir = os.path.join(self.working_dir, proj.name)
             proj.dependencies = [Project.get_project(dep) for dep in proj.dependencies]
             proj.dependents = []
+            proj.load_defaults(self)
 
         for proj in Project.list_projects():
             self.__compute_deps(proj)

--- a/harfbuzz/win32/config-msvc.mak
+++ b/harfbuzz/win32/config-msvc.mak
@@ -56,27 +56,10 @@ HB_TESTS_DEP_LIBS = $(HB_GLIB_LIBS)
 # Use libtool-style DLL names, if desired
 !if "$(LIBTOOL_DLL_NAME)" == "1"
 HARFBUZZ_DLL_FILENAME = $(CFG)\$(PLAT)\libharfbuzz-0
-HARFBUZZ_ICU_DLL_FILENAME = $(CFG)\$(PLAT)\libharfbuzz-icu-0
 HARFBUZZ_GOBJECT_DLL_FILENAME = $(CFG)\$(PLAT)\libharfbuzz-gobject-0
 !else
-HARFBUZZ_DLL_FILENAME = $(CFG)\$(PLAT)\harfbuzz
-HARFBUZZ_ICU_DLL_FILENAME = $(CFG)\$(PLAT)\harfbuzz-icu
-HARFBUZZ_GOBJECT_DLL_FILENAME = $(CFG)\$(PLAT)\harfbuzz-gobject
-!endif
-
-# Enable HarfBuzz-ICU, if desired
-!if "$(ICU)" == "1"
-HB_ICU_CFLAGS =
-HB_LIBS =	\
-	$(HB_LIBS)	\
-	$(CFG)\$(PLAT)\harfbuzz-icu.lib
-
-# We don't want to re-define int8_t Visual Studio 2008, will cause build breakage
-# as we define it in hb-common.h, and we ought to use the definitions there.
-!if "$(VSVER)" == "9"
-HB_ICU_CFLAGS = /DU_HAVE_INT8_T
-!endif
-
+HARFBUZZ_DLL_FILENAME = $(CFG)\$(PLAT)\harfbuzz-vs$(VSVER)
+HARFBUZZ_GOBJECT_DLL_FILENAME = $(CFG)\$(PLAT)\harfbuzz-gobject-vs$(VSVER)
 !endif
 
 # Enable Introspection (enables HarfBuzz-Gobject as well)
@@ -177,9 +160,30 @@ HB_TESTS = \
 	$(CFG)\$(PLAT)\test-unicode.exe				\
 	$(CFG)\$(PLAT)\test-version.exe
 
-!else
-# If there is no GLib support, use the built-in UCDN
+!elseif "$(ICU)" == "1"
+# use ICU for Unicode functions
 # and define some of the macros in GLib's msvc_recommended_pragmas.h
+# to reduce some unneeded build-time warnings
+HB_DEFINES = $(HB_DEFINES) /DHAVE_ICU=1 /DHAVE_ICU_BUILTIN=1
+HB_CFLAGS =	\
+	$(HB_CFLAGS)					\
+	/wd4244							\
+	/D_CRT_SECURE_NO_WARNINGS		\
+	/D_CRT_NONSTDC_NO_WARNINGS
+
+# We don't want ICU to re-define int8_t in VS 2008, will cause build breakage
+# as we define it in hb-common.h, and we ought to use the definitions there.
+!if "$(VSVER)" == "9"
+HB_CFLAGS =	$(HB_CFLAGS) /DU_HAVE_INT8_T
+!endif
+
+HB_SOURCES = $(HB_SOURCES) $(HB_ICU_sources)
+HB_HEADERS = $(HB_HEADERS) $(HB_ICU_headers)
+HB_DEP_LIBS = $(HB_DEP_LIBS) $(HB_ICU_DEP_LIBS)
+!endif
+
+!if "$(UCDN)" != "0"
+# Define some of the macros in GLib's msvc_recommended_pragmas.h
 # to reduce some unneeded build-time warnings
 HB_DEFINES = $(HB_DEFINES) /DHAVE_UCDN=1
 HB_CFLAGS =	\


### PR DESCRIPTION
…ironment

Resolve #124. 

I have to move up the platform detection & normalization (x86 -> Win32) before checking the vs presence otherwise or the gtk path was missing (attribute error) or badly set (the default is x86 so I end up with a path of c:\gtk-build\gtk\x86\.... instead of .. gtk\win32\ ..
