### PR TITLE
Download and use cmake

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ HexChat developers decided that their script should focus on their specific need
 1. We try to follow as much as possible the conventions of the upstream MSVC projects by Fan Chun-wei - [Compiling the GTK+ (and Clutter) stack using Visual C++ 2008 and later](https://wiki.gnome.org/action/show/Projects/GTK+/Win32/MSVCCompilationOfGTKStack).
 1. We are pretty liberal about adding more libraries to the script - at some point we will need to make the set of libraries that are built configurable and easily extensible, but right now we are ok with adding libraries that are useful to the users of this script
 1. We try to fetch tarballs from their original locations - if patches are needed we try to fork the project on github and host a patched tarball there
+1. We try to download the tools needed and using them from a local directory, without any installation. Actually we use directly cmake, meson, ninja and nuget.
 
 ## Building
 
 1. Install the following build tools and dependencies:
 
     * [Visual Studio 2013 Express for Windows Desktop](http://www.visualstudio.com/downloads/download-visual-studio-vs#d-2013-express) - Any version of VS apart from 2013 is not supported.
-    * [CMake 3.0.2](http://www.cmake.org/download/) (also works with CMake 2.8.x)
     * [msys2](https://msys2.github.io/)
     * Perl 5.20 [x86](https://dl.hexchat.net/misc/perl/perl-5.20.0-x86.7z) or [x64](https://dl.hexchat.net/misc/perl/perl-5.20.0-x64.7z) (extract to _C:\perl_)
     * [Python 3.4](https://www.python.org/ftp/python/2.7.9/python-2.7.9.amd64.msi) (install in C:\Python34), or other package like [Miniconda 3.4](https://repo.continuum.io/miniconda/Miniconda3-latest-Windows-x86_64.exe)


### PR DESCRIPTION
Using the new Tool path feature, I get the latest version (3.7.2.) for x64.

I update and tested (with vs2015) all the projects builded with cmake and everything seems good except for libyuv that doesn't compile (but it's not a problem with the cmake version because there are problems even if I try with the 3.0.2 version, the 'official' one, of cmake) 
I also don't test the hg ones (pycairo, pygoject, pygtk) because I have some issues with my setup and it gives me an error at the download, sorry :(